### PR TITLE
Update rogue base docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tidair/smurf-rogue:R1.0.1
+FROM tidair/smurf-rogue:R1.0.2
 
 # Install the SMURF PCIe card repository
 WORKDIR /usr/local/src


### PR DESCRIPTION
Applies rogue bugfix:

https://github.com/slaclab/smurf-rogue-docker/releases/tag/R1.0.2