### PR TITLE
Patch the PCIe core software which uses a method not supported

### DIFF
--- a/patches/SmurfKcu1500RssiOffload_Core.path
+++ b/patches/SmurfKcu1500RssiOffload_Core.path
@@ -1,7 +1,16 @@
 diff --git a/software/python/SmurfKcu1500RssiOffload/_Core.py b/software/python/SmurfKcu1500RssiOffload/_Core.py
-index d6cfac5..a763e02 100644
+index d6cfac5..2324d15 100644
 --- a/software/python/SmurfKcu1500RssiOffload/_Core.py
 +++ b/software/python/SmurfKcu1500RssiOffload/_Core.py
+@@ -33,7 +33,7 @@ class EthPhyGrp(pr.Device):
+             self.add(ethPhy.TenGigEthReg(
+                 name    = f'EthPhy[{i}]',
+                 offset  = i*0x1000,
+-                writeEn = True,
++                #writeEn = True,
+                 expand  = False,
+             ))
+
 @@ -84,12 +84,12 @@ class UdpBufferGrp(pr.Device):
              **kwargs):
          super().__init__(name=name, description=description, **kwargs)


### PR DESCRIPTION
in the current version of SMuRF